### PR TITLE
Quickfix: Exclude the template file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -46,3 +46,6 @@ theme: minima
 
 plugins:
  - jekyll-feed
+
+exclude:
+  - newsletter-template.md


### PR DESCRIPTION
This PR excludes the template file to fix this:

![image](https://user-images.githubusercontent.com/662976/65806899-a0c22c00-e194-11e9-92ac-029dbd300f8f.png)

_Follow up to #21_