### PR TITLE
Fix sort order on the homepage

### DIFF
--- a/content/posts/_index.md
+++ b/content/posts/_index.md
@@ -2,4 +2,5 @@
 redirect_to = "/"
 insert_anchor_links = "right"
 page_template = "post.html"
+sort_by = "date"
 +++

--- a/templates/includes/home.html
+++ b/templates/includes/home.html
@@ -29,7 +29,7 @@
     {% set posts = get_section(path="posts/_index.md") %}
     {% if posts and posts.pages | length > 0 %}
         <ul class="post-list">
-            {% for post in posts.pages | reverse %}
+            {% for post in posts.pages %}
                 <li>
                     {% if post.date %}
                         {% set date_format = config.extra.date_format | default(value="%b %-d, %Y") %}


### PR DESCRIPTION
As noticed by @ozkriff, the homepage wasn't actually being sorted in date order. Upon some digging, I found that they were actually being sorted in reverse alphabetical order - it just so happened that we've not broken that pattern of post names since the site launched 😆

In my defense, [the Zola theme I used as reference for implementing this site also makes this mistake...](https://github.com/getzola/hyde/blob/master/templates/index.html#L54)

The fix is to properly sort the `posts` section by date, and then remove the reversing logic from the template. This also has the nice side effect of giving us access to the next/previous post as template variables, so I might integrate that into the template at a later date 😄 
