### PR TITLE
Fix box sizing on post images

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -63,6 +63,7 @@ h6:hover .anchor {
 
 .post-content p img {
     display: block;
+    box-sizing: border-box;
     margin: 16px auto;
     padding: 8px;
     border: 1px solid #e8e8e8;


### PR DESCRIPTION
Whoops, I forgot the Minima theme doesn't have everything set to `box-sizing: border-box`.

Fixes #76.