### PR TITLE
Update Zola to 0.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BASE_URL: https://github.com/getzola/zola/releases/download
-      VERS: v0.10.1
+      VERS: v0.11.0
       ARCH: x86_64-unknown-linux-gnu
       # https://github.com/marketplace/actions/github-pages#warning-limitation
       GITHUB_PAT: ${{ secrets.GITHUB_PAT }}

--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,8 @@ base_url = "https://rust-gamedev.github.io/"
 default_language = "en"
 compile_sass = true
 highlight_code = true
-generate_rss = true
+generate_feed = true
+feed_filename = "rss.xml"
 
 [extra]
 date_format = "%F"

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -7,6 +7,11 @@ li {
     margin: 15px 0;
 }
 
+pre > code {
+    // To avoid grey background on code blocks.
+    background-color: inherit;
+}
+
 .intro {
     color: #ffffff;
     background-color: $brand-color;


### PR DESCRIPTION
* Updated the CI to use Zola 0.11
* Fixed an issue with the way the CSS was rendering the new code block markup
* Changed the feed settings to keep the existing behaviour from the previous version (seems a bit pointless to do another redirect if we don't have to)