### PR TITLE
Add centered image captions using MD/CSS hack

### DIFF
--- a/content/posts/newsletter-001/index.md
+++ b/content/posts/newsletter-001/index.md
@@ -116,8 +116,7 @@ Also, check out
 ### Way of Rhea [Trailer][rhea trailer] and [Steam Wishlist][rhea steam] Announced
 
 [![Part of the trailer](way-of-rhea.gif)][rhea trailer]
-
-^ _click on the GIF to see [the full trailer][rhea trailer]_
+_click on the GIF to see [the full trailer][rhea trailer]_
 
 [A new trailer][rhea trailer] and the [Steam wishlist][rhea steam]
 were published for "Way of Rhea" by [Anthropic Studios].
@@ -522,8 +521,7 @@ by [Michael Fairley] was released:
 > and make sure to press all the buttons.
 
 [![Part of A snake's Tail's trailer](a-snakes-tail.gif)][snake trailer]
-
-^ _click on the GIF to see [the full release trailer][snake trailer]_
+_click on the GIF to see [the full release trailer][snake trailer]_
 
 A few posts about the game and how it was developed:
 

--- a/content/posts/newsletter-003/index.md
+++ b/content/posts/newsletter-003/index.md
@@ -524,8 +524,7 @@ Also, see this GameDev WG tracker/complaint issue:
 ### [RLSL][rlsl]: a Rust to SPIR-V Compiler
 
 ![RLSL code sample](rlsl-example.png)
-
-^ _a simple fragment shader that renders a red circle (temporary syntax)_
+_a simple fragment shader that renders a red circle (temporary syntax)_
 
 This month, [@MaikKlein_DEV] gave a talk at
 [The Khronos Group](https://www.khronos.org)'s meetup in Munich
@@ -559,8 +558,7 @@ _Discussions:
 ### [gfx-rs v0.4][gfx-v0-4]
 
 ![sailor screenshot: vector terrain map and some basic UI](sailor.png)
-
-^ _a screenshot from [Yatekii/sailor] - a wgpu-based sailing navigation application_
+_a screenshot from [Yatekii/sailor] - a wgpu-based sailing navigation application_
 
 [gfx-rs v0.4 was released](https://reddit.com/r/rust/comments/dm89t2/gfxhal_version_04_release):
 major changes were described in [the last blog post](https://gfx-rs.github.io/2019/10/01/update.html),
@@ -686,8 +684,7 @@ _Discussions:
 ### [cyclone-physics-rs]
 
 [![cyclone physics demo](cyclone-physics-demo.gif)][cyclone-video-demo]
-
-^ _a little demo of "particle" simulation_
+_a little demo of "particle" simulation_
 
 [cyclone-physics-rs] by [@heyrutvik] a new WIP game physics engine
 based on the ["Game Physics Engine Development" book][cyclone-physics-book].

--- a/content/posts/newsletter-004/index.md
+++ b/content/posts/newsletter-004/index.md
@@ -201,8 +201,7 @@ about the implementation of a drop table system to handle monster loot.
 ### [Recall Singularity: November Progress][recall-s-nov-text]
 
 [![Demo of the basic ship collision](recall-sing.gif)][recall-s-nov-video]
-
-^ _Demo of the basic ship collision._
+_Demo of the basic ship collision._
 
 [Tom Leys] is working on a "The Recall Singularity" game
 about designing autonomous factory ships and stations
@@ -778,8 +777,7 @@ and highlight events from the past. -->
 Just an interesting Rust gamedev link from the past. :)
 
 [![Pascal Penguin logo](penguin.png)][penguin-video]
-
-^ _click to see the [release trailer][penguin-video]_
+_click to see the [release trailer][penguin-video]_
 
 ["Adventures of Pascal Penguin"][penguin-about]
 by [Matthew Michelotti](http://luduminis.com)

--- a/content/posts/newsletter-005/index.md
+++ b/content/posts/newsletter-005/index.md
@@ -258,8 +258,7 @@ _Discussions:
 ### [Garden Devlog: December][garden-dec]
 
 [![Playing with dirt](garden.gif)][garden-video]
-
-^ _new smooth soil editing demo_
+_new smooth soil editing demo_
 
 [Garden][garden] is an upcoming game centered around growing realistic plants.
 
@@ -856,8 +855,7 @@ and highlight events from the past. -->
 Just an interesting Rust gamedev link from the past. :)
 
 [![Modulator video](modulator_youtube.gif)][modulator-video]
-
-^ _click to see [the tutorial video][modulator-video]_
+_click to see [the tutorial video][modulator-video]_
 
 In the November of 2018,
 [@AndreaPessino] (Founder/CTO of [Ready At Dawn] Studios)

--- a/content/posts/newsletter-006/index.md
+++ b/content/posts/newsletter-006/index.md
@@ -838,8 +838,7 @@ Btw, [@resinten] continues working on a luminance-based game:
 ### [SPIR-Q][spir-q] v0.4.1
 
 ![Example walking an entry point of a SPIR-V file](spir-q.png)
-
-^ _Example walking an entry point of a SPIR-V file_
+_Example walking an entry point of a SPIR-V file_
 
 [SPIR-Q][spir-q] is a lightweight [SPIR-V] query library.
 This month v0.2..v0.4.1 versions were released:

--- a/content/posts/newsletter-007/index.md
+++ b/content/posts/newsletter-007/index.md
@@ -177,8 +177,7 @@ This month an alpha version was published on itch: [check it out here][colony-it
 ### [Veloren][veloren]
 
 ![Rolling mountain landscape](veloren1.png)
-
-^ _Rolling mountain landscape_
+_Rolling mountain landscape_
 
 [Veloren][veloren] is an open world, open-source voxel RPG
 inspired by Dwarf Fortress and Cube World.
@@ -215,8 +214,7 @@ Here is the February changelog:
 ```
 
 [![veloren development](veloren3.gif)](https://youtube.com/watch?v=1ldHQfxCT24)
-
-^ _1 year of Veloren development. Click for the full video!_
+_1 year of Veloren development. Click for the full video!_
 
 You can read more about some specific topics:
 
@@ -245,8 +243,7 @@ February's full weekly devlogs: "This Week In Veloren...":
 ### [Oxidator][oxidator]
 
 [![Gameplay demo: two giant tank armies clashing](oxidator-play.gif)][oxidator-video-play]
-
-^ _gameplay demo (35000 units)_
+_gameplay demo (35000 units)_
 
 [Oxidator][oxidator] by [@Ruddle] is a real-time strategy game/engine
 written with Rust and WebGPU.
@@ -273,12 +270,10 @@ Some of the current features:
   (speed, turn rate, health, etc);
 
 [![Unit editor demo: move agent's parts](oxidator-unit-editor.gif)][oxidator-video-unit-editor]
-
-^ _Demo of the unit editor_
+_Demo of the unit editor_
 
 [![Map editor demo: use pencil tool to instantly create a lake and mountains](oxidator-map-editor.gif)][oxidator-video-map-editor]
-
-^ _Demo of the map editor_
+_Demo of the map editor_
 
 [oxidator]: https://github.com/Ruddle/oxidator
 [@Ruddle]: https://github.com/Ruddle
@@ -490,8 +485,7 @@ Tetra itself also received two small updates recently:
 ### [Akigi][akigi]
 
 ![High detail terrain chunk with PRR](akigi.png)
-
-^ _Sampling a heightmap in the vertex shader and also computing the normal,
+_Sampling a heightmap in the vertex shader and also computing the normal,
 tangent and bitangent vectors in the vertex shader._
 
 [Akigi][akigi] is a multiplayer online world where most believe that humans are inferior.
@@ -596,8 +590,7 @@ Check them out in the [latest winter devlog][grumpy_visitors].
 ### [Make China Great Again][china-great]
 
 ![cities, planes and keys](china.png)
-
-^ _Turn back planes to the port, by clicking right keys to the virus beat._
+_Turn back planes to the port, by clicking right keys to the virus beat._
 
 [Make China Great Again][china-great] ([source][china-great-src])
 by [@PsichiX] is a GlobalGameJam game written using [Oxygengine].
@@ -640,8 +633,7 @@ dependency updates, bugfixes and performance optimizations.
 ### [Recall Singularity: February Progress][recall-s-feb]
 
 ![Harvesting and refining some Gold](recall-singularity.png)
-
-^ _Harvesting and refining some Gold._
+_Harvesting and refining some Gold._
 
 [Tom Leys] is working on a "The Recall Singularity" game
 about designing autonomous factory ships and stations.
@@ -913,8 +905,7 @@ A showcase game is [being developed](https://github.com/lcnr/akari) with crow.
 ### miniquad: ["Rust 2D Engine 2020 Roadmap"][fedor-road]
 
 ![mainloop async/await experiment in macroquad](miniquad-sample.png)
-
-^ _mainloop async/await experiment in macroquad_
+_mainloop async/await experiment in macroquad_
 
 [miniquad] by [@fedor_games] is a safe cross-platform rendering library
 focused on portability and low-end platforms support.

--- a/content/posts/newsletter-008/index.md
+++ b/content/posts/newsletter-008/index.md
@@ -334,8 +334,7 @@ Some of this month's updates:
 ### [Veloren][veloren]
 
 ![LoD](veloren1.png)
-
-^ _Work on Level of Detail_
+_Work on Level of Detail_
 
 [Veloren][veloren] is an open world, open-source voxel RPG
 inspired by Dwarf Fortress and Cube World.
@@ -434,8 +433,7 @@ Main updates:
 ### gfx-rs and wgpu news
 
 ![Deeper game](deeper.png)
-
-^ _[deeper] uses wgpu for rendering_
+_[deeper] uses wgpu for rendering_
 
 [gfx-hal-0.5](https://github.com/gfx-rs/gfx/) was released!
 Improvements done in March:
@@ -519,8 +517,7 @@ Some of this month's updates:
 ### [Nannou v0.13][nannou-post]
 
 ![Daily Sketch 0114 by Mactuitui](nannou.png)
-
-^ _Daily Sketch 0114 by Mactuitui_
+_Daily Sketch 0114 by Mactuitui_
 
 [Nannou][nannou] is a creative coding framework that aims to make it easy
 for artists to express themselves with simple, fast, reliable code.

--- a/content/posts/newsletter-009/index.md
+++ b/content/posts/newsletter-009/index.md
@@ -247,8 +247,7 @@ Follow [@seratonik] on Twitter for updates.
 ### [Akigi][akigi]
 
 ![shadows demo](akigi-shadows.jpeg)
-
-^ _new shadows_
+_new shadows_
 
 > [Akigi][akigi] is a multiplayer online world where humans
 > aren't the only intelligent animals.
@@ -480,8 +479,7 @@ Here's a roundup of some of them:
 ### [Veloren][veloren]
 
 ![Buildings](veloren1.png)
-
-^ _Early procedural building generation_
+_Early procedural building generation_
 
 [Veloren][veloren] is an open world, open-source voxel RPG
 inspired by Dwarf Fortress and Cube World.
@@ -519,8 +517,7 @@ Here is the April changelog:
 ```
 
 ![Hanging out](veloren2.png)
-
-^ _Early procedural building generation_
+_Early procedural building generation_
 
 You can read more about some specific topics from April:
 
@@ -635,8 +632,7 @@ explaining why they've chosen Rust for their project's backend.
 ### [Symmetric Matrices & Triangle Numbers][matrices-post]
 
 ![an example of a multi-layered game level](rhea-player-orb.jpeg)
-
-^ _The pink orb should not collide with the player,
+_The pink orb should not collide with the player,
 but it should collide with the ground._
 
 [Anthropic Studios][anthropic] has [shared a post][matrices-post]
@@ -742,8 +738,7 @@ and additional information about contributing are available on the [github repos
 ### `gfx-rs` and `wgpu` News
 
 ![hectic screenshot: graveyard and vampires](hectic.png)
-
-^ _[hectic-rs] - Rust/wgpu/specs re-write of hectic by [@expenses]_
+_[hectic-rs] - Rust/wgpu/specs re-write of hectic by [@expenses]_
 
 wgpu-0.5 release happened! See the [changelog][wgpu-0-5].
 It's based on `gfx-hal-0.5` (which was covered in the [March newsletter][gfx-march]),
@@ -888,8 +883,7 @@ in an eternally sprawling office complex.
 ### [miniquad]
 
 ![miniquad logo](miniquad_logo.png)
-
-^ _`miniquad` project got a logo_
+_`miniquad` project got a logo_
 
 [miniquad] is a safe and cross-platform rendering library
 focused on portability and low-end platforms support.
@@ -1130,8 +1124,7 @@ and highlight events from the past. -->
 Just an interesting Rust gamedev link from the past. :)
 
 ![example](valora-example.jpeg)
-
-^ _"dead end" by turnage, 2019_
+_"dead end" by turnage, 2019_
 
 A few months ago a  generative art library ["valora"][valora-src]
 was released by [@turnage].

--- a/content/posts/newsletter-010/index.md
+++ b/content/posts/newsletter-010/index.md
@@ -64,8 +64,7 @@ If needed, a section can be split into subsections with a "------" delimiter.
 ### [Veloren][veloren]
 
 ![Buildings](veloren1.png)
-
-^ _The new repo banner_
+_The new repo banner_
 
 [Veloren][veloren] is an open world, open-source voxel RPG inspired by Dwarf
 Fortress and Cube World.
@@ -80,8 +79,7 @@ account][veloren-opencollective], and you can donate towards our infrastructure
 costs. GamingOnLinux [wrote an article][gamingonlinux] on Veloren's development.
 
 [![0.6 release trailer](veloren_trailer.gif)](https://www.youtube.com/watch?v=kjDFVgWYMd4)
-
-^ _0.6 release trailer. Click for the full video!_
+_0.6 release trailer. Click for the full video!_
 
 Here is the May changelog:
 
@@ -115,8 +113,7 @@ of 0.7, and what they wanted to achieve:
 > interact with the game UI to do this.
 
 ![Welcome to Veloren](veloren2.png)
-
-^ _Welcome to Veloren! From the 0.6 release party_
+_Welcome to Veloren! From the 0.6 release party_
 
 You can read more about some specific topics from May:
 
@@ -216,8 +213,7 @@ Some of the updates:
 ### [Sandbox]
 
 [![Sandbox gameplay demo](sandbox.jpeg)](https://streamable.com/0bhbol#)
-
-^ _click to see a gameplay demo_
+_click to see a gameplay demo_
 
 [Sandbox] is a falling sand game by JMS55 that provides a variety of fun
 particle types to place, and then you get to watch the resulting interactions!
@@ -324,8 +320,7 @@ Follow [@seratonik] on Twitter for updates.
 ### [Crate Before Attack][cratebeforeattack-site]
 
 [![screenshot: decision tree and goal distance map in the background](crate_before_attack.png)][cratebeforeattack-site]
-
-^ _Decision tree and goal distance map in the background_
+_Decision tree and goal distance map in the background_
 
 [Crate Before Attack][cratebeforeattack-site] by [koalefant (@CrateAttack)][@CrateAttack]
 is a realtime/turn-based multiplayer game where frogs combat their friends
@@ -391,8 +386,7 @@ the first time. Be sure to check out the [Github repo][digescape-github].
 ### [Akigi][akigi]
 
 ![cat model](akigi1.png)
-
-^ _Completed cat model with rigging_
+_Completed cat model with rigging_
 
 > [Akigi][akigi] is a magical multiplayer online world where humans aren't the
 > only intelligent animals. Akigi is a solo project, and the developer hopes to
@@ -426,8 +420,7 @@ Full devlogs:
 ### Nox Futura: Rust Edition
 
 ![worldgen menu](nox-f.png)
-
-^ _Worldgen menu_
+_Worldgen menu_
 
 [Herbert Wolverson][thebracket]
 (the author of [bracket-lib] and [the Rust Roguelike Tutorial][rl-book])
@@ -646,8 +639,7 @@ _Discussions:
 ### NodeFX
 
 [![NodeFX](nodefx.png)][NodeFXTweet]
-
-^ _Click the image to see the animated version_
+_Click the image to see the animated version_
 
 Project "NodeFX" by [Christian Vallentin (@MrVallentin)][@MrVallentin]
 is an unnamed node-based tool for creating GLSL shaders in real-time,

--- a/content/posts/newsletter-011/index.md
+++ b/content/posts/newsletter-011/index.md
@@ -93,8 +93,7 @@ Also, participants are encouraged to
 ### [Way of Rhea][rhea-site]
 
 [![Way of Rhea Trailer](way-of-rhea.jpeg)][rhea-trailer]
-
-^ _Click to see the latest version of the game's trailer_
+_Click to see the latest version of the game's trailer_
 
 [Way of Rhea][rhea-site] ([steam][rhea-steam])
 is an upcoming puzzle platformer that takes place in a world
@@ -130,8 +129,7 @@ or [subscribe to its newsletter][rhea-newsletter].
 ### [A/B Street][abstreet] - Adjust Traffic Patterns in Real Cities
 
 ![Measuring the effects of changes](abstreet-evaluating-impacts.gif)
-
-^ _Measuring the effects of some changes_
+_Measuring the effects of some changes_
 
 [A/B Street][abstreet] is a traffic simulation game exploring how
 small changes to roads affect cyclists, transit users, pedestrians, and drivers.
@@ -162,8 +160,7 @@ A/B Street uses a [custom GUI library][ezgui], leveraging `glium`, `usvg`, and
 ### [Crate Before Attack][cba-site]
 
 [![In-game visual scripting prototype](crate_before_attack.gif)][cba-youtube-scripting]
-
-^ _In-game visual scripting prototype_
+_In-game visual scripting prototype_
 
 [Crate Before Attack][cba-site] by [koalefant (@CrateAttack)][@CrateAttack]
 is a skill-based grappling hook multiplayer game where frogs combat their friends
@@ -214,8 +211,7 @@ Some of the updates from [the June devlog][garden-devlog]:
 ### [Veloren][veloren]
 
 ![Animation improvements](veloren-wolf.gif)
-
-^ _Animation improvements_
+_Animation improvements_
 
 [Veloren][veloren] is an open world, open-source voxel RPG inspired by Dwarf
 Fortress and Cube World.
@@ -285,8 +281,7 @@ Also, check out [a talk about open source and Veloren][veloren-talk]:
 ### [Zero to Game][zerotoga.me]
 
 ![ships with greater thrust explode](zerotogame-destruction.gif)
-
-^ _The initial destruction prototype applied across different thrust levels_
+_The initial destruction prototype applied across different thrust levels_
 
 [Zero to Game][zerotoga.me] is a project that documents
 the creation of an independent space game from zero.
@@ -384,8 +379,7 @@ Web, Mac, Linux, Windows (untested) & possible even iOS & Android.
 ### [Animal Chess][AnimalChess]
 
 ![Part of the game map](animal-chess.jpeg)
-
-^ _Part of the game map_
+_Part of the game map_
 
 [Animal Fight Chess][AnimalChess] (斗兽棋, "Doe Show Chee") by [@netcan]
 is a Rust implementation of a popular Chinese game.
@@ -469,8 +463,7 @@ Two devlogs were released this month:
 ### [Weegames][weegames-itch]
 
 [![Weegames](weegames.jpg)][weegames-video]
-
-^ _Click to see [a demo video][weegames-video]_
+_Click to see [a demo video][weegames-video]_
 
 [Weegames][weegames-itch] is a fast-paced minigame collection.
 There are 23 odd games all made using free images and sounds.
@@ -509,8 +502,7 @@ The demo's source code [could be found here][hypervis].
 ### [Boids in Rust][rboids-post-1]
 
 [![Boids demo](rboids-video.jpeg)][rboids-video]
-
-^ _Click to watch [the video demo][rboids-video]_
+_Click to watch [the video demo][rboids-video]_
 
 [@twitu] has published a three-part blog series
 about simulating a group of virtual agents (boids)
@@ -632,8 +624,7 @@ seemed like now is the time to address such issues in the API.
 ### [This Month in Mun][mun-june]
 
 ![Language Server Diagnostics in action](mun-languageserver.gif)
-
-^ _Mun language server diagnostics in action_
+_Mun language server diagnostics in action_
 
 [Mun] is a scripting language for gamedev focused on quick iteration times
 that is written in Rust.

--- a/content/posts/newsletter-012/index.md
+++ b/content/posts/newsletter-012/index.md
@@ -64,8 +64,7 @@ If needed, a section can be split into subsections with a "------" delimiter.
 ### [ochre][4k-post] - 4K Intro
 
 [![Youtube preview: mountains & spheres](4k-into-youtube.jpeg)][4k-video]
-
-^ _Click to [watch the demo on Youtube][4k-video]._
+_Click to [watch the demo on Youtube][4k-video]._
 
 Jani Peltonen has recently released a [4K intro][4k-src]
 which is completely written in Rust and GLSL
@@ -117,8 +116,7 @@ _Discussions:
 ### [Crate Before Attack][cba-site]
 
 [![Golf Club in Crate Before Attack](crate-before-attack.gif)][cba-site]
-
-^ _A new weapon: the Golf Club_
+_A new weapon: the Golf Club_
 
 [Crate Before Attack][cba-site] by [koalefant (@CrateAttack)][@CrateAttack]
 is a skill-based grappling hook multiplayer game where frogs combat their friends
@@ -473,8 +471,7 @@ The game is in an early stage of development,
 ### [On FPS Game Progress \#2][on-fps-game-2]
 
 [![fps-game-screenshot](fps-game-2.jpeg)][on-fps-game-2-youtube]
-
-^ _Click to watch [footage from the game's current state][on-fps-game-2-youtube]._
+_Click to watch [footage from the game's current state][on-fps-game-2-youtube]._
 
 On this update, [@pingFromHeaven] talks about the lighting implementation that
 sets the tone for the game, how Rust is good at shortening the debugging
@@ -512,8 +509,7 @@ Some of the recent updates:
 ### [Veloren][veloren]
 
 ![Sunrise](veloren-sunrise.gif)
-
-^ _Sunrise_
+_Sunrise_
 
 [Veloren][veloren] is an open world, open-source voxel RPG inspired by Dwarf
 Fortress and Cube World.
@@ -528,8 +524,7 @@ crafting GUI has been added. Translations have stabilized significantly, and
 there is a framework for translators to know what needs to be done.
 
 ![Fire particles](veloren-fire.gif)
-
-^ _Progress on the particle system_
+_Progress on the particle system_
 
 You can read more about some specific topics from July:
 
@@ -554,8 +549,7 @@ generation. The inaugural episode of the Rust Game Dev podcast will be released,
 which features an interview by Veloren developers.
 
 ![Quadrupeds](veloren-quadrupeds.png)
-
-^ _Quadruped overhaul_
+_Quadruped overhaul_
 
 [veloren]: https://veloren.net
 
@@ -605,8 +599,7 @@ read the book at [sokoban.iolivia.me][sokoban_book].
 ### [Make Pong with Rust][tantan-video]
 
 [![youtube preview](video-pong-tutorial.jpeg)][tantan-video]
-
-^ _Click to [watch the tutorial][tantan-video]._
+_Click to [watch the tutorial][tantan-video]._
 
 [TanTan] released a [video tutorial][tantan-video]
 that guides you through all the step of making a pong game in Rust
@@ -645,8 +638,7 @@ The full article is available [here][dod].
 ### ["Rust'N'Games" Talk][rust-n-games]
 
 [![youtube preview: a slide with Tower Rangers game](rust-n-games-youtube.jpeg)][rust-n-games]
-
-^ _Click to [watch the talk][rust-n-games]._
+_Click to [watch the talk][rust-n-games]._
 
 During the recent ["Rust and Tell"][rust-n-tell] online event
 [Stephan @extrawurst Dilly][@extrawurst] gave a ["Rust'N'Games" talk][rust-n-games]
@@ -818,8 +810,7 @@ Linux, macOS and Windows!
 ### [wgpu][wgpu-site]
 
 ![procgen dynamic "grass field"](tuitui-grass-field.jpeg)
-
-^ _[@MacTuitui]'s everyday [nannou] experiment #1274_
+_[@MacTuitui]'s everyday [nannou] experiment #1274_
 
 The work is ongoing to validate all the incoming commands and guarantee API safety.
 Special thanks to [@GabrielMajeri] for helping to convert assertions
@@ -940,8 +931,7 @@ You can follow progress on [GitHub][graphene] or on [Twitter][apoorvaj].
 ### Vulkan Renderer (Name TBD)
 
 [![Vulkan renderer on iOS prototype](vulkan-renderer-prototype.jpeg)][vulkan-renderer-prototype-video]
-
-^ _Click to watch [the video demo][vulkan-renderer-prototype-video] running on iOS._
+_Click to watch [the video demo][vulkan-renderer-prototype-video] running on iOS._
 
 [@aclysma] published a [new vulkan-based renderer][renderer-prototype] that
 uses [atelier-assets] to load 3D scenes exported from blender.
@@ -1099,8 +1089,7 @@ and highlight events from the past. -->
 Just an interesting Rust gamedev link from the past. :)
 
 [![youtube preview](shar-youtube.jpeg)][shar-trailer]
-
-^ _Click to watch [SHAR's Greenlight trailer][shar-trailer]_
+_Click to watch [SHAR's Greenlight trailer][shar-trailer]_
 
 [SHAR][shar-itch] (Russian "Шар" - ball) by [@fedor_games] (author of [miniquad]/[macroquad])
 is a 3rd-person online action game that aims to create unique experience

--- a/content/posts/newsletter-013/index.md
+++ b/content/posts/newsletter-013/index.md
@@ -65,8 +65,7 @@ If needed, a section can be split into subsections with a "------" delimiter.
 ### [Crate Before Attack][cba-site]
 
 [![Camera debugging in Crate Before Attack](crate-before-attack.png)][cba-site]
-
-^ _Debugging camera motion: highlighted areas are points of interest._
+_Debugging camera motion: highlighted areas are points of interest._
 
 [Crate Before Attack][cba-site] by [koalefant (@CrateAttack)][@CrateAttack]
 is a skill-based multiplayer game where frogs combat their friends
@@ -178,8 +177,7 @@ work with graphics in Rust using [SDL2][sdl2] library.
 ### [Beginning Game Development with Amethyst][rustconf-talk-video]
 
 [![youtube preview](rustconf-amethyst-talk.png)][rustconf-talk-video]
-
-^ _Click to [watch the talk][rustconf-talk-video]._
+_Click to [watch the talk][rustconf-talk-video]._
 
 Getting started with Rust + gamedev can be intimidating. At
 [RustConf 2020][rust-conf-2020], [Micah Tigley] gave a talk about their experience

--- a/newsletter-template.md
+++ b/newsletter-template.md
@@ -30,6 +30,7 @@ Ideal section structure is:
 ### [Title]
 
 ![image/GIF description](image link)
+_image caption_
 
 A paragraph or two with a summary and [useful links].
 

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -100,3 +100,12 @@ a.btn {
         border-color: $brand-color;
     }
 }
+
+// A hack for image captions.
+// See https://stackoverflow.com/questions/19331362/using-an-image-caption-in-markdown-jekyll
+img + em,
+a:first-child + em:last-child {
+    display: block;
+    text-align: center;
+    color: $grey-color;
+}


### PR DESCRIPTION
This PR uses a [MD/CSS hack](https://stackoverflow.com/questions/19331362/using-an-image-caption-in-markdown-jekyll) to add centered image captions.


<details><summary>before/after imgs</summary>
<p>
Before:

![image](https://user-images.githubusercontent.com/662976/92305942-7415b780-ef94-11ea-81af-b9fb0aa88395.png)

After:

![image](https://user-images.githubusercontent.com/662976/92305931-66603200-ef94-11ea-8a6a-9286e6f7cd46.png)

</p>
</details>