### PR TITLE
Update Zola to 0.12.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BASE_URL: https://github.com/getzola/zola/releases/download
-      VERS: v0.11.0
+      VERS: v0.12.2
       ARCH: x86_64-unknown-linux-gnu
       # https://github.com/marketplace/actions/github-pages#warning-limitation
       GITHUB_PAT: ${{ secrets.GITHUB_PAT }}


### PR DESCRIPTION
I held off on updating to 0.12 cause it was broken on Windows, but the latest patches seem to have fixed that.

I tried building the site with 0.12.2 and it all seems to work without any changes - figured it'd be a good idea to stay up to date, so that contributors don't have to download old versions of Zola.