### PR TITLE
Automatically comment if a PR doesn't meet the style guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: Zola
 
-on: [push, pull_request]
+on:
+  push:
+    branches: source
+  pull_request:
 
 jobs:
   zola:
@@ -18,6 +21,17 @@ jobs:
       with:
         args: '.'
         config: '.markdownlint.json'
+    - name: Comment if lints failed
+      if: failure() && github.base_ref # base_ref is only set for PRs 
+      uses: actions/github-script@v3
+      with:
+        script: |
+          github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: "It looks like the MarkdownLint checks for this PR have failed. Please take a look at the 'Checks' tab to see what needs changing."
+          });
     - name: Install Zola
       run: curl -L ${BASE_URL}/${VERS}/zola-${VERS}-${ARCH}.tar.gz | tar -xz
     - run: ./zola --version


### PR DESCRIPTION
🤖 🤖 🤖 

One common problem we have with the newsletter each month is misformatted PRs - sometimes people submit them and then don't check whether the build has passed, which means @ozkriff and me have to chase them up. This seemed like it should be a really easy thing to automate, and that turned out to be the case :)

I've tested this PR on a fork of the repo, and it seems to work okay (and it's using an official GitHub action package, so should be reasonably stable). It currently comments every time a PR build fails, but I could limit it to once per PR if we want - what do people think?

![image](https://user-images.githubusercontent.com/784533/106324101-7b559e80-6270-11eb-99ae-d050d3d62bdd.png)

I also amended the run conditions for the CI job to not run multiple builds per PR.
