### PR TITLE
Custom Domain: gamedev.rs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 title = "Rust Game Development Working Group"
 description = "Stay up to date with the progress and recent developments in the Rust Game Development Working Group."
-base_url = "https://rust-gamedev.github.io/"
+base_url = "https://gamedev.rs/"
 default_language = "en"
 compile_sass = true
 highlight_code = true

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+gamedev.rs


### PR DESCRIPTION
Closes #233 (_"Custom Domain"_)
Related to #586 (_"Shorter URLs + split "posts" into news+blog"_)