### PR TITLE
Center and abbreviate the site's title

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-title = "Rust Game Development Working Group"
+title = "Rust GameDev WG"
 description = "Stay up to date with the progress and recent developments in the Rust Game Development Working Group."
 base_url = "https://gamedev.rs/"
 default_language = "en"

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -15,6 +15,14 @@ pre > code {
 .site-header {
     // To avoid a thick black line on top of the page.
     border-top: none;
+
+    // To center the site's title.
+    text-align: center;
+}
+
+.site-title {
+    // To center the site's title.
+    float: none;
 }
 
 .intro {


### PR DESCRIPTION
I'd like to make the site's title shorter & centered because atm it looks kinda weird on mobile.

![image](https://user-images.githubusercontent.com/662976/114726567-2e994400-9d46-11eb-923e-99637ad7fb42.png)
