### PR TITLE
Fix formatting issue on chip-8-rs

### DIFF
--- a/content/news/021/index.md
+++ b/content/news/021/index.md
@@ -966,7 +966,7 @@ GUI.
 _Debugging Pong_
 
 [Chip-8-rs][chip-8-rs] by @jonathanmurray is
-a _CHIP-8_ emulator with some basic debugging functionality.
+a CHIP-8 emulator with some basic debugging functionality.
 
 When running a game through the emulator, CHIP-8 instructions are listed
 next to the main display, with the currently executed one highlighted. By


### PR DESCRIPTION
#589

Didn't spot this until after merging, the italics here get rendered like an image caption...