### PR TITLE
Fix misaligned header on mobile

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -23,6 +23,7 @@ pre > code {
 .site-title {
     // To center the site's title.
     float: none;
+    padding: 0;
 }
 
 .intro {


### PR DESCRIPTION
Minima adds some padding at small screen sizes that doesn't play nice with our centered header.

Before:

![image](https://user-images.githubusercontent.com/784533/117620798-bcf7be80-b168-11eb-871e-ac98fff9b4b3.png)

After:

![image](https://user-images.githubusercontent.com/784533/117620819-c5e89000-b168-11eb-89e0-ef27edb829ec.png)
