### PR TITLE
PR template: Replace CONTRIBUTING link with link to parent

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,3 @@
-Please, read the [contributing guidelines][contributing] before submitting a PR.
+<!-- Please, insert the parent issue's id below. Example: "_Part of #589_" -->
 
-[contributing]: https://github.com/rust-gamedev/rust-gamedev.github.io/blob/source/CONTRIBUTING.md
+_Part of #TODO_


### PR DESCRIPTION
The current template is somewhat meaningless because:
- a lot of contributors leave the current template text as is
- and CONTRIBUTING.md isn't updated to the actual current guidelines.