### PR TITLE
Template: separate tooling and no-toc

### DIFF
--- a/newsletter-template.md
+++ b/newsletter-template.md
@@ -32,7 +32,8 @@ Feel free to send PRs about your own projects!
 - [Game Updates](#game-updates)
 - [Learning Material Updates](#learning-material-updates)
 - [Engine Updates](#engine-updates)
-- [Library & Tooling Updates](#library-tooling-updates)
+- [Tooling Updates](#tooling-updates)
+- [Library Updates](#library-updates)
 - [Popular Workgroup Issues in Github](#popular-workgroup-issues-in-github)
 - [Meeting Minutes](#meeting-minutes)
 - [Requests for Contribution](#requests-for-contribution)
@@ -67,7 +68,9 @@ If needed, a section can be split into subsections with a "------" delimiter.
 
 ## Learning Material Updates
 
-## Library & Tooling Updates
+## Tooling Updates
+
+## Library Updates
 
 ## Popular Workgroup Issues in Github
 

--- a/newsletter-template.md
+++ b/newsletter-template.md
@@ -4,6 +4,8 @@ transparent = true
 draft = true
 +++
 
+<!-- no toc -->
+
 <!-- Check the post with markdownlint-->
 
 Welcome to the {TODO}th issue of the Rust GameDev Workgroup's


### PR DESCRIPTION
>  would it be a good idea to add that <!-- no toc --> to the template? We're always having issues with this plugin breaking the TOC, so would be good to disable that