### PR TITLE
N24: Fix crop on Emerald logo

### DIFF
--- a/content/news/024/em_logo.svg
+++ b/content/news/024/em_logo.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="100%" height="100%" viewBox="0 0 4000 1500" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+<svg width="100%" height="100%" viewBox="0 0 1500 1500" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
     <g transform="matrix(1.65375,0,0,1.65375,-427.665,-244.944)">
         <g transform="matrix(-1,1.22465e-16,-1.77341e-16,-1.4481,1110.98,1718.55)">
             <path d="M400.105,467.654L518.375,750L400.105,558.157L281.835,750L400.105,467.654Z"/>


### PR DESCRIPTION
<!-- Please, insert the parent issue's id below. Example: "_Part of #589_" -->

_Part of #719_

It's currently weirdly left aligned:

![image](https://user-images.githubusercontent.com/784533/128637090-687c76ff-0b68-4f50-8728-9521c447155a.png)
