### PR TITLE
Fix anchors for Zola 0.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BASE_URL: https://github.com/getzola/zola/releases/download
-      VERS: v0.14.1
+      VERS: v0.15.2
       ARCH: x86_64-unknown-linux-gnu
       # https://github.com/marketplace/actions/github-pages#warning-limitation
       GITHUB_PAT: ${{ secrets.GITHUB_PAT }}

--- a/content/news/016/index.md
+++ b/content/news/016/index.md
@@ -30,7 +30,6 @@ Feel free to send PRs about your own projects!
 
 Table of contents:
 
-- [Rust GameDev Podcast](#rust-gamedev-podcast)
 - [Last Call for Rust GameDev Survey](#last-call-for-rust-gamedev-survey)
 - [Game Updates](#game-updates)
 - [Learning Material Updates](#learning-material-updates)

--- a/content/news/016/index.md
+++ b/content/news/016/index.md
@@ -30,6 +30,7 @@ Feel free to send PRs about your own projects!
 
 Table of contents:
 
+- [Rust GameDev Podcast #3](#rust-gamedev-podcast-3)
 - [Last Call for Rust GameDev Survey](#last-call-for-rust-gamedev-survey)
 - [Game Updates](#game-updates)
 - [Learning Material Updates](#learning-material-updates)

--- a/content/news/017/index.md
+++ b/content/news/017/index.md
@@ -29,6 +29,7 @@ Feel free to send PRs about your own projects!
 
 Table of contents:
 
+- [Rust GameDev Podcast #4](#rust-gamedev-podcast-4)
 - [Rust Gamedev Meetup](#rust-gamedev-meetup)
 - [Game Updates](#game-updates)
 - [Learning Material Updates](#learning-material-updates)

--- a/content/news/017/index.md
+++ b/content/news/017/index.md
@@ -30,7 +30,6 @@ Feel free to send PRs about your own projects!
 Table of contents:
 
 - [Rust Gamedev Meetup](#rust-gamedev-meetup)
-- [Rust GameDev Podcast](#rust-gamedev-podcast)
 - [Game Updates](#game-updates)
 - [Learning Material Updates](#learning-material-updates)
 - [Library & Tooling Updates](#library-tooling-updates)

--- a/content/news/020/index.md
+++ b/content/news/020/index.md
@@ -31,8 +31,6 @@ Feel free to send PRs about your own projects!
 - [Learning Material Updates](#learning-material-updates)
 - [Engine Updates](#engine-updates)
 - [Library & Tooling Updates](#library-tooling-updates)
-- [Popular Workgroup Issues in Github](#popular-workgroup-issues-in-github)
-- [Meeting Minutes](#meeting-minutes)
 - [Requests for Contribution](#requests-for-contribution)
 
 <!--
@@ -559,7 +557,7 @@ Notable changes:
 
 [Harvest Hero][hh_disc] ([Discord][hh_disc], [Twitter][bmb_twitter])
 by [@bombfuse][bmb_twitter] is an arcade/roguelite where you whack Groobles.
-Built on top of [Emerald](#Emerald).
+Built on top of [Emerald](#emerald).
 
 Harvest Hero has undergone a large change, migrating
 from semi-randomly generated levels to handcrafted levels


### PR DESCRIPTION
I'm on the latest version of Zola, and I had to remove these links since Zola appears to now check that anchors lead to somewhere properly. Good feature though!