### PR TITLE
N30: Discussions and Jobs

### DIFF
--- a/content/news/030/index.md
+++ b/content/news/030/index.md
@@ -628,7 +628,7 @@ or [join the next meeting][join].
 useful information -->
 
 - [/r/rust](https://www.reddit.com/r/rust/):
-  - ["Rust alternative for PyGame?"](https://reddit.com/r/rust/comments/ru86vu/rust_alternative_for_pygame) 
+  - ["Rust alternative for PyGame?"](https://reddit.com/r/rust/comments/ru86vu/rust_alternative_for_pygame)
 
 ## Requests for Contribution
 

--- a/content/news/030/index.md
+++ b/content/news/030/index.md
@@ -627,6 +627,9 @@ or [join the next meeting][join].
 <!-- Links to handpicked reddit/twitter/urlo/etc threads that provide
 useful information -->
 
+- [/r/rust](https://www.reddit.com/r/rust/):
+  - ["Rust alternative for PyGame?"](https://reddit.com/r/rust/comments/ru86vu/rust_alternative_for_pygame) 
+
 ## Requests for Contribution
 
 <!-- Links to "good first issue"-labels or direct links to specific tasks -->
@@ -634,6 +637,9 @@ useful information -->
 ## Jobs
 
 <!-- An optional section for new jobs related to Rust gamedev -->
+
+- [Embark Studios](https://careers.embark-studios.com/jobs)
+  (Stockholm/Hybrid Remote) - Various roles
 
 ## Bonus
 


### PR DESCRIPTION
<!-- Please, insert the parent issue's id below. Example: "_Part of #589_" -->

_Part of #912_

We don't usually fill in the Jobs section, but I've seen various people from Embark tweeting about vacancies in the last few weeks so it seemed worth doing this month. Let me know what you think of the formatting (and whether this should be a regular thing we do?)

Followed @ozkriff's formatting from last month for the discussions section, seemed much cleaner than how I did it last time I was editor :)