### PR TITLE
Allow CI to push file deletions (fixes #945)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,3 @@ jobs:
       with:
         build_dir: public
         target_branch: master
-        keep_history: true


### PR DESCRIPTION
As mentioned on #945, there's an upstream issue with the CI action we use to publish to GitHub Pages where if `keep_history` is set to `true`, files will never be deleted from the `master` branch, even if they're no longer present in Zola's output. The default is `false`, which effectively force pushes to `master` every time, meaning that it will always reflect exactly what was generated by the most recent Zola run.

Given that we never actually utilize the history on the `master` branch (e.g. if we do a revert, we generally just revert on `source` and let the site republish), I don't think there's much value to keeping the history around? I think it would be worth switching back to the default here.