### PR TITLE
Use built in Github token instead of personal access token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
       BASE_URL: https://github.com/getzola/zola/releases/download
       VERS: v0.15.2
       ARCH: x86_64-unknown-linux-gnu
-      # https://github.com/marketplace/actions/github-pages#warning-limitation
-      GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+      # https://github.com/crazy-max/ghaction-github-pages/issues/1#issuecomment-623202206
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v2
     - name: Lint


### PR DESCRIPTION
Noticed while making a change to arewegameyet that we don't need to use a personal access token here any more.
