### PR TITLE
Replace MoleTrooper -> Molentum; update related links

### DIFF
--- a/content/news/013/index.md
+++ b/content/news/013/index.md
@@ -1104,7 +1104,7 @@ _Discussions:
 
 ![Current state of starframe graphics and physics](starframe-demo.gif)
 
-[starframe] by [@moletrooper] is a work-in-progress 2D game engine
+[starframe] by [@molentum] is a work-in-progress 2D game engine
 for physics-y sidescrolling games. This month it received
 [an experimental graph-based entity system][sf-graph-post].
 
@@ -1113,11 +1113,11 @@ generalized constraints, which will enable things like friction and joints.
 
 _Discussions:
 [/r/rust](https://www.reddit.com/r/rust/comments/iju3xq/starframe_devlog_architecture_ecs_graph/),
-[twitter](https://twitter.com/moletrooper/status/1300034941816897542)_
+[twitter](https://twitter.com/molentum_/status/1300034941816897542)_
 
-[starframe]: https://github.com/moletrooper/starframe
-[@moletrooper]: https://twitter.com/moletrooper
-[sf-graph-post]: https://moletrooper.github.io/blog/2020/08/starframe-1-architecture/
+[starframe]: https://github.com/m0lentum/starframe
+[@molentum]: https://twitter.com/molentum_
+[sf-graph-post]: https://molentum.me/blog/starframe-architecture/
 
 ### [mochi]
 

--- a/content/news/017/index.md
+++ b/content/news/017/index.md
@@ -1006,16 +1006,16 @@ or follow [Dmitry Stepanov on Twitter][rg3d_twitter].
 
 ![Current state of starframe graphics and physics](starframe.gif)
 
-[starframe] by [@moletrooper] is a work-in-progress game engine
+[starframe] by [@molentum] is a work-in-progress game engine
 for physics-y sidescrolling 2D games. This month, a new, more versatile
 constraint solver was used to add friction and basic joints. Collision
 detection accuracy and overall stability were also improved.
 
 _Discussions:
-[twitter](https://twitter.com/moletrooper/status/1338066680724008960)_
+[twitter](https://twitter.com/molentum_/status/1338066680724008960)_
 
-[starframe]: https://github.com/moletrooper/starframe
-[@moletrooper]: https://twitter.com/moletrooper
+[starframe]: https://github.com/m0lentum/starframe
+[@molentum]: https://twitter.com/molentum_
 
 ### [Dotrix]
 

--- a/content/news/020/index.md
+++ b/content/news/020/index.md
@@ -664,7 +664,7 @@ demonstrating some useful patterns for structuring a Tetra project.
 
 ![Current state of starframe graphics and physics](starframe.gif)
 
-[Starframe] by [@moletrooper] is a work-in-progress game engine for physics-y
+[Starframe] by [@molentum] is a work-in-progress game engine for physics-y
 sidescrolling 2D games.
 
 This month, [its physics engine was revamped once more][sf-update-tweet]
@@ -674,10 +674,10 @@ Also, [a blog post][sf-blog-post] was published, covering the
 development of the physics engine so far in a great deal of mathematical
 detail.
 
-[starframe]: https://github.com/moletrooper/starframe
-[@moletrooper]: https://twitter.com/moletrooper
-[sf-blog-post]: https://moletrooper.github.io/blog/2021/03/starframe-devlog-constraints
-[sf-update-tweet]: https://twitter.com/moletrooper/status/1360723470414450688
+[starframe]: https://github.com/m0lentum/starframe
+[@molentum]: https://twitter.com/molentum_
+[sf-blog-post]: https://molentum.me/blog/starframe-constraints/
+[sf-update-tweet]: https://twitter.com/molentum_/status/1360723470414450688
 
 ### Emerald
 

--- a/content/news/024/index.md
+++ b/content/news/024/index.md
@@ -423,16 +423,16 @@ game engine! Join them on their [Discord server][emerald-discord].
 
 ![Demonstration of Starframe's new rope physics](starframe.gif)
 
-[Starframe] by [@moletrooper] is a work-in-progress game engine for physics-y
+[Starframe] by [@molentum] is a work-in-progress game engine for physics-y
 sidescrolling 2D games.
 
 This month's noteworthy development was [particle-based ropes][sf-ropes-tweet]
 capable of full two-way coupling with rigid bodies, demonstrated above.
 Capsule-shaped colliders were also added.
 
-[starframe]: https://github.com/MoleTrooper/starframe/
-[@moletrooper]: https://twitter.com/moletrooper
-[sf-ropes-tweet]: https://twitter.com/moletrooper/status/1421204030441889792
+[starframe]: https://github.com/m0lentum/starframe/
+[@molentum]: https://twitter.com/molentum_
+[sf-ropes-tweet]: https://twitter.com/molentum_/status/1421204030441889792
 
 ## Learning Material Updates
 

--- a/content/news/026/index.md
+++ b/content/news/026/index.md
@@ -465,7 +465,7 @@ fork and PR!
 ![physically-connected groups of primitives are framed with rectangles](starframe-islands.jpeg)
 _Grouping bodies into disjoint "islands"_
 
-[Starframe] by [@moletrooper] is a work-in-progress game engine for physics-y
+[Starframe] by [@molentum] is a work-in-progress game engine for physics-y
 sidescrolling 2D games.
 
 This month, a lot of work was done on optimizing the physics engine.
@@ -479,10 +479,10 @@ sense to work on the engine without a concrete project to use it.
 Thus, work has begun on a platformer based around connecting things with ropes.
 More details to be shown soonish!
 
-[Starframe]: https://github.com/MoleTrooper/starframe/
-[@moletrooper]: https://twitter.com/moletrooper
-[sf-grid-tweet]: https://twitter.com/moletrooper/status/1432441648890449920
-[sf-island-tweet]: https://twitter.com/moletrooper/status/1438877808412008450
+[Starframe]: https://github.com/m0lentum/starframe/
+[@molentum]: https://twitter.com/molentum_
+[sf-grid-tweet]: https://twitter.com/molentum_/status/1432441648890449920
+[sf-island-tweet]: https://twitter.com/molentum_/status/1438877808412008450
 
 ### [Arcana]
 

--- a/content/news/030/index.md
+++ b/content/news/030/index.md
@@ -853,7 +853,7 @@ the [demo video of 100k birds][bevy-smud-birds]
 [System Fault]: https://www.lightsout.games/news/system-fault-early-access
 [Lantern]: https://qatoqat.itch.io/lantern
 [Fish Fight]: https://spicylobster.itch.io/fishfight/devlog/332434/fish-fights-past-present-and-future
-[Starframe]: https://moletrooper.me/blog/starframe-ropes/
+[Starframe]: https://molentum.me/blog/starframe-ropes/
 [Cake Thieves]: https://play.google.com/store/apps/details?id=com.GeTech.CakeThieves
 [Idu]: https://twitter.com/logicsoup/status/1487924659693703169
 [Sugarcane]: https://gitlab.com/macmv/sugarcane


### PR DESCRIPTION
I've decided to change my username, and with that some links in newsletters I've been featured in have been broken (or will be eventually when they stop redirecting to my new profiles). This patches links to my stuff to point to the right places again.