### PR TITLE
N49: goku

### DIFF
--- a/content/news/049/index.md
+++ b/content/news/049/index.md
@@ -69,6 +69,26 @@ If needed, a section can be split into subsections with a "------" delimiter.
 
 ## Engine Updates
 
+### goku game engine
+[goku game engine] ([GitHub](https://github.com/ladroid/goku)) by [@ladroid](https://github.com/ladroid) crafted entirely in Rust and backed by SDL2. Currently compatible with Windows and WASM, and featuring multi-language support (Spanish, French, German, Japanese).
+
+Quick Peek:
+
+- SpriteSheet & Animated Textures
+- TextureManager & GameObject
+- Tile System & Particle Effects
+- UI Layer & Audio
+- AI & Window System
+- Visual Treats
+- Timing
+
+Also, a GUI interface is still under development, though it's in its budding stages.
+
+_Discussions: [/r/rust](https://reddit.com/r/rust/comments/165luwu/introducing_goku_engine)_
+
+[goku]: https://github.com/ladroid/goku
+[@ladroid]: https://github.com/ladroid
+
 ## Learning Material Updates
 
 ## Tooling Updates

--- a/content/news/049/index.md
+++ b/content/news/049/index.md
@@ -70,7 +70,10 @@ If needed, a section can be split into subsections with a "------" delimiter.
 ## Engine Updates
 
 ### goku game engine
-[goku game engine] ([GitHub](https://github.com/ladroid/goku)) by [@ladroid](https://github.com/ladroid) crafted entirely in Rust and backed by SDL2. Currently compatible with Windows and WASM, and featuring multi-language support (Spanish, French, German, Japanese).
+[goku game engine] ([GitHub](https://github.com/ladroid/goku)) by [@ladroid](https://github.com/ladroid) 
+is a game engine crafted entirely in Rust and backed by SDL2. 
+Currently compatible with Windows and WASM, 
+and featuring multi-language support (Spanish, French, German, Japanese).
 
 Quick Peek:
 

--- a/content/news/049/index.md
+++ b/content/news/049/index.md
@@ -69,28 +69,31 @@ If needed, a section can be split into subsections with a "------" delimiter.
 
 ## Engine Updates
 
-### goku game engine
-[goku game engine] ([GitHub](https://github.com/ladroid/goku)) by [@ladroid](https://github.com/ladroid) 
-is a game engine crafted entirely in Rust and backed by SDL2. 
-Currently compatible with Windows and WASM, 
-and featuring multi-language support (Spanish, French, German, Japanese).
+### [goku]
+
+[goku] ([Discord][goku-dis]) by [@ladroid] is a new 2D Rust game engine
+backed by SDL2. It's currently compatible with Windows and WASM
+and features [multi-language (Spa, Fra, Ger, Jpn) docs][goku-docs].
 
 Quick Peek:
 
-- SpriteSheet & Animated Textures
-- TextureManager & GameObject
-- Tile System & Particle Effects
-- UI Layer & Audio
-- AI & Window System
-- Visual Treats
-- Timing
+- Sprite sheets loading and animation support.
+- Basic particle effects.
+- Point, spot, and ambient lights.
+- UI layer with ready widgets like buttons, checkboxes, and sliders.
+- Audio support backed by SDL2 Mixer.
+- Gamepad input support.
+- Tile system and JSON format for describing scenes.
+- Built-in support for parallax backgrounds.
+- Simple timing and frame management utils.
+- Behavior tree AIs.
 
-Also, a GUI interface is still under development, though it's in its budding stages.
-
-_Discussions: [/r/rust](https://reddit.com/r/rust/comments/165luwu/introducing_goku_engine)_
+_Discussions: [/r/rust](https://reddit.com/r/rust/comments/165luwu/intro_goku)_
 
 [goku]: https://github.com/ladroid/goku
 [@ladroid]: https://github.com/ladroid
+[goku-docs]: https://lados-organization.gitbook.io/goku
+[goku-dis]: https://discord.gg/9TAMqdRyED
 
 ## Learning Material Updates
 


### PR DESCRIPTION
Part of https://github.com/rust-gamedev/rust-gamedev.github.io/issues/1440

Adds a section for [goku](https://github.com/ladroid/goku) under "Engine Updates".
