### PR TITLE
Simplify lints

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,12 +1,7 @@
 {
     "line-length": {
-        "line_length": 80,
+        "line_length": 160,
         "code_blocks": false
-    },
-    "ul-style": {
-        "style": "dash"
-    },
-    "no-trailing-punctuation": {
-        "punctuation": ".,;:。，；："
     }
 }
+

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,6 +2,9 @@
     "line-length": {
         "line_length": 160,
         "code_blocks": false
+    },
+    "no-trailing-punctuation": {
+        "punctuation": ".,;:。，；："
     }
 }
 


### PR DESCRIPTION
Fixes #639 
Additionally removes lint for ul list style.

I'm relaxing our lints massively because I want to streamline the process for potential contributors by reducing as much friction as possible. If the current editors since the revival find the lints too relaxed, I'm very open to changing them in the next release cycle.
