### PR TITLE
Improve issue template and optimize schedule

### DIFF
--- a/.github/newsletter-issue-template.md
+++ b/.github/newsletter-issue-template.md
@@ -4,17 +4,14 @@ labels: coordination, help wanted
 assignees: AngelOnFira, mamaicode, janhohenheim
 ---
 
-# Newsletter {{ env.NEWSLETTER_COUNTER}}: {{ env.NEWSLETTER_MONTH }} {{ env.NEWSLETTER_YEAR }}
-
 **Editors:** @janhohenheim, @AngelOnFira, @mamaicode
 
 Another month has gone by, so it's time to put together the Rust Gamedev newsletter with {{ env.NEWSLETTER_MONTH }}'s news!
 
 ## Current Schedule
 
-The deadline for all section PRs is the **3rd of {{ env.NEWSLETTER_NEXT_MONTH}}, {{ env.NEWSLETTER_YEAR }}**
-
-We _may_ still accept PRs that are submitted later than this, as long as they're ready before the newsletter's release, but this isn't guaranteed. If you want your section to be included, don't leave it till the last minute!
+The deadline for all section PRs is the **28th of {{ env.NEWSLETTER_MONTH}}, {{ env.NEWSLETTER_YEAR }}**. Submissions after this date will be added to the next newsletter.
+Our target release date is the **3rd of {{ env.NEWSLETTER_NEXT_MONTH }}, {{ env.NEWSLETTER_YEAR }}**.
 
 ## Current Structure & Status
 
@@ -24,39 +21,62 @@ This is **not** an exhaustive list - if you have your own project that you want 
 
 ### Game Updates
 
-- TODO
+None yet. Feel free to submit yours!
 
 ### Learning Material Updates
 
-- TODO
+None yet. Feel free to submit yours!
 
 ### Engine Updates
 
-- TODO
+None yet. Feel free to submit yours!
 
 ### Tooling Updates
 
-- TODO
+None yet. Feel free to submit yours!
 
 ### Library Updates
 
-- TODO
+None yet. Feel free to submit yours!
 
 ### Other News
 
-- TODO
+None yet. Feel free to submit yours!
 
 ### Discussions
 
-- TODO
+None yet. Feel free to submit yours!
+
+## Calls for Submissions
+
+### Social Media
+
+- [ ] Reddit
+- [ ] Lemmy
+- [ ] Mastodon
+- [ ] Twitter/X
+- [ ] Hacker News
+
+### Discord Servers
+
+- [ ] Rust GameDev
+- [ ] Bevy
+- [ ] Blue Engine
+- [ ] Macroquad
+- [ ] Fyrox
+- [ ] LogLogGames (comfy engine)
+- [ ] Spicy Lobster
+- [ ] Rust Godot
+
+Let us know if you also want to receive monthly reminders on your Discord server!
 
 ## Publishing Steps
 
 - [ ] Final review - by everyone
 - [ ] Publish - by @janhohenheim
-- [ ] Post on /r/rust, /r/rust_gamedev, /r/gamedev, URLO - by @janhohenheim
-- [ ] Pin thread on Twitter - by @AngelOnFira
-- [ ] Add comment links - by @AngelOnFira
+- [ ] Post together with next calls for submissions - by @janhohenheim
+- [ ] Pin thread on social media - by @janhohenheim
+- [ ] Add comment links - by @janhohenheim
 
 ## How to Contribute
 
@@ -69,7 +89,7 @@ If you want to help writing the newsletter:
   - You are not obligated to write a section if you're tagged or your project is listed! You're welcome to ask someone else to write the section, or to ask for your project to be excluded from this month's post.
   - Extra sections not listed in the plan are welcomed - just leave a comment and open a PR!
 - Write a short overview in the newsletter's Markdown file, making sure to follow the style guidelines (see below).
-- Send a PR _to the `source` branch_ (example: [N15: A/B Street #336](https://github.com/rust-gamedev/rust-gamedev.github.io/pull/336)).
+- Send a PR [_to the `source` branch_](https://github.com/rust-gamedev/rust-gamedev.github.io/tree/source) (example PR: [N15: A/B Street #336](https://github.com/rust-gamedev/rust-gamedev.github.io/pull/336)).
 - Mention this issue in your PR's description to link it all together.
 
 ## Style Guidelines
@@ -78,7 +98,7 @@ The full style guide is in [CONTRIBUTING.md](https://github.com/rust-gamedev/rus
 but here are the most important rules:
 
 - Write in third-person perspective.
-- Each line must be 80 characters or less, for ease of reviewing/diffing.
+- Each line must be 160 characters or less, for ease of reviewing/diffing.
 - Only one image per section is allowed.
   - The maximum size is 300kb for static images and 2.5mb for GIFs.
   - The image should come before the text, and must have alt text for accessibility.

--- a/.github/workflows/create-newsletter.yaml
+++ b/.github/workflows/create-newsletter.yaml
@@ -1,8 +1,8 @@
 name: Create Newsletter
 on:
   schedule:
-    # Run on the 5th of every month at 12pm
-    - cron: "0 12 5 * *"
+    # Run on the 3rd of every month at 9 am
+    - cron: "0 9 3 * *"
   workflow_dispatch:
     inputs: {}
 permissions:


### PR DESCRIPTION
- Remove duplicate title
- Fix outdated lint information
- Remove TODOs
- Add reminders for which places to post the monthly updates on (All of the Discord server's moderation teams have agreed to get these)
- Assign me to some things
- Merge monthly calls for submissions with spreading the released newsletter
- Move the generation of the next newsletter to the publication date
- Adopt the freeze period schedule proposed by @Vrixyz in https://github.com/rust-gamedev/rust-gamedev.github.io/issues/1417#issuecomment-1764534286

From the linked issue, the schedule is as follows:
```mermaid
timeline
    title This Month in Rust Gamedev News
    3rd : Release previous news entry!
        : (Release) social media posts, 
        : (Release) links to discussions
        : Add a draft of next month's newsletter
    4th-27th : Contributor creates an issue
        : Community/editors review
        : Merge into source
    28th : PR freeze<br> Expect any pending PRs to be reported.
         : Last touches<br>global review pass
```
The only difference here is is that I changed the `1st` to the `3rd` to have some more time for editing.