### PR TITLE
Fix links

### DIFF
--- a/content/news/049/index.md
+++ b/content/news/049/index.md
@@ -341,7 +341,7 @@ mobile/WASM support and the need to pre-define events & states.
 
 [dexterous_developer]: https://github.com/lee-orr/dexterous_developer
 [@lee-orr]: https://github.com/lee-orr
-[Bevy]: bevyengine.org
+[Bevy]: https://bevyengine.org
 
 ### [nanogltf]
 

--- a/content/news/049/index.md
+++ b/content/news/049/index.md
@@ -291,7 +291,7 @@ Google Play Store.
 
 ## Tooling Updates
 
-### [Space editor](space_editor)
+### [Space editor][space_editor]
 
 ![Space editor window with opened level](space_editor.png)
 

--- a/content/news/049/index.md
+++ b/content/news/049/index.md
@@ -151,48 +151,6 @@ _Discussions: [r/rust](https://reddit.com/r/rust/comments/167qyn0/oort)_
 [@rlane]: https://github.com/rlane
 [oort-tournament]: https://github.com/rlane/oort3/wiki/Tournament-Writeup-2023%E2%80%9009%E2%80%9011
 
-### [Ars Militaris][arsm]
-
-![Ars Militaris Logo](arsmilitaris.png)
-
-[Ars Militaris][arsm] ([GitHub][arsm-gh], [Discord][arsm-dis],
-[Twitter][arsm-twi], [Reddit][arsm-red])
-is a turn-based tactics game set in the ancient Rome era,
-being developed with Bevy.
-
-August saw some nice developments that occurred in both the
-digital and board game version of Ars Militaris. You can
-read about them in issues VI through IX of This Week in Ars Militaris
-([VI](https://arsmilitaris.com#this-week-in-ars-militaris-vi),
-[VII](https://arsmilitaris.com#this-week-in-ars-militaris-vii),
-[VIII](https://arsmilitaris.com#this-week-in-ars-militaris-viii),
-[IX](https://arsmilitaris.com#this-week-in-ars-militaris-ix)).
-
-The most noticeable improvements in the digital version were
-the updating of the multiplayer aspect to be on par with the
-single-player aspect, and then also the development of the
-[Ars Militaris Lobby][arsm-lobby].
-
-In the board game version, development started on a new
-scenario that will serve as our main product for the Ars
-Militaris board game version, and much playtesting with
-very positive results occurred
-[(Ars Militaris Event III)][arsm-event-iii]
-and [(Ars Militaris Event IV)][arsm-event-iv].
-
-But then, the result of a somewhat intensive 3-month
-sprint left the Lead Developer exhausted which brought
-the project to a temporary pause.
-
-[arsm]: https://arsmilitaris.com
-[arsm-gh]: https://github.com/arsmilitaris
-[arsm-twi]: https://twitter.com/ArsMilitarisDev
-[arsm-dis]: https://discord.gg/cdNDQsstgq
-[arsm-red]: https://reddit.com/r/arsmilitaris
-[arsm-lobby]: https://arsmilitaris.com#ars-militaris-lobby
-[arsm-event-iii]: https://arsmilitaris.com#ars-militaris-event-iii
-[arsm-event-iv]: https://arsmilitaris.com#ars-militaris-event-iv
-
 ### [Tiny Glade]
 
 ![A vibrant fantasy castle in a lush forest glade](tinyglade.jpg)

--- a/content/news/049/index.md
+++ b/content/news/049/index.md
@@ -295,7 +295,7 @@ Google Play Store.
 
 ![Space editor window with opened level](space_editor.png)
 
-[Space editor](space_editor) is an editor designed for Bevy engine
+[Space editor][space_editor] is an editor designed for Bevy engine
 that simplifies level and object template creation. Here are its key features:
 
 - Intuitive UI is built on top of bevy-inspector-egui and egui-gizmo


### PR DESCRIPTION
Removes Ars Militaris. The dead links are blocking the build. The game also seems to abandoned based on all domains used being dead.

<!-- Please, insert the parent issue's id below. Example: "_Part of #589_" -->

_Part of #1440_