### PR TITLE
Add newsletter changes blog post

### DIFF
--- a/content/blog/newsletter-changes/index.md
+++ b/content/blog/newsletter-changes/index.md
@@ -1,0 +1,64 @@
++++
+title = "Newsletter Changes"
+date = 2024-05-02
+transparent = true
++++
+
+Hey everyone, it's been a while! As you've certainly noticed, the newsletter was
+on a hiatus for a while. The reason was mostly maintainer burnout, which is also
+why the newsletter of August 2023 was not published [until a few days
+ago][august-news].
+
+We're back now though! The community member Jan Hohenheim ([@janhohenheim]) has
+taken up the main responsibility for reviving the newsletter. This includes
+making changes requested by the community, and making sure the format is
+sustainable for the long term. 
+
+### Schedule Changes
+
+Thierry Berger ([@Vrixyz]), who has also decided to help with the project, has
+come up with a new [monthly schedule][monthly_schedule] that we will try out:
+
+- 3rd of the month: Newsletter starts. A call for submissions is made on social
+media and community Discord servers interested in receiving it. At the same
+time, last month's newsletter is published.
+- 3rd to 28th of the month: submissions are collected and the newsletter is
+  written.
+- 28th of the month: Submissions are closed. New submissions go into the next
+  month's newsletter.
+- 3rd of the next month: The newsletter is published. Any submissions not edited
+in time will be moved to the next month or removed entirely.
+
+This more strict schedule should help with the issue of late entries and reduce
+the pressure of editing by having a dedicated time for it with no incoming
+submissions. The goal is to be more consistent and reliable in our publishing
+schedule.
+
+### Community Survey
+
+This restructuring is also a good time to improve the content of the newsletter.
+We've got some community feedback on our [Discord] already and would like to
+hear more from you. It would be great if you could fill out [this
+survey][survey] to let us know how we can improve the newsletter going forward.
+The survey closes on the **28th of May**.
+
+### Future Steps
+
+Based on feedback we've already gotten, the steps for next months are:
+- Add an email subscription option to the newsletter
+- Setup a system for how to edit entries that are not ready before the
+newsletter ships. We are currently looking into either hiring a part-time
+editor, using generative AI to add a few sentences where needed, or simply
+removing these entries.
+
+Additionally, we will be evaluating the [survey] results in the next newsletter,
+so stay tuned for that.
+
+That's all for now. Have fun reading!
+
+[august-news]: https://gamedev.rs/news/049/
+[@janhohenheim]: https://github.com/janhohenheim
+[@Vrixyz]: https://github.com/Vrixyz
+[monthly_schedule]: https://github.com/rust-gamedev/rust-gamedev.github.io/issues/1417#issuecomment-1764534286
+[survey]: https://forms.gle/oeSb46twWsxRKYJe7
+[Discord]: https://discord.gg/game-development-in-rust-676678179678715904


### PR DESCRIPTION
This takes blog-oriented content out of N50 and puts it in its own post. I probably need to make some more changes before it goes out (I made some other wording changes in N50 that I should copy over here, but it should be good to discuss.