### PR TITLE
quick change to the thing i made sm64jsarchive (N50: sm64jsarchive #1474)

### DIFF
--- a/content/news/050/index.md
+++ b/content/news/050/index.md
@@ -108,18 +108,16 @@ For the full changelog, see the [release notes][wor-release-notes].
 ![Super Mario 64 JavaScript](sm64jsarchive.jpg)
 
 [SM64JSARCHIVE][sm64jsarchive] is an actively maintained fork of [sm64js]: a decompilation project of Super Mario 64 to JavaScript.
-The code is open-sourced on [GitHub][sm64jsarchive-github].
+Additional sidenote: the servers arent always running
 
-The [backend server][sm64jsarchive-server], which is written in Rust,
+The backend server, which is written in Rust,
 has finally been able to start after 10 long months
 and is now live at <https://mmo.sm64jsarchive.com>
 
 A successful stress test for the MMO feature was run on April 10th.
 
 [sm64jsarchive]: https://mmo.sm64jsarchive.com
-[sm64jsarchive-github]: https://github.com/uuphoria2/sm64jsarchive
 [sm64js]: https://github.com/sm64js/sm64js
-[sm64jsarchive-server]: https://github.com/sm64jsarchived/sm64jsarchive-mmo-server
 
 ### [Open Combat][OpenCombat_website]
 

--- a/content/news/050/index.md
+++ b/content/news/050/index.md
@@ -108,7 +108,7 @@ For the full changelog, see the [release notes][wor-release-notes].
 ![Super Mario 64 JavaScript](sm64jsarchive.jpg)
 
 [SM64JSARCHIVE][sm64jsarchive] is an actively maintained fork of [sm64js]: a decompilation project of Super Mario 64 to JavaScript.
-Additional sidenote: the servers arent always running
+Additional sidenote: The mmo servers arent always running for the game
 
 The backend server, which is written in Rust,
 has finally been able to start after 10 long months


### PR DESCRIPTION
Part of #1474

This is a patch. The github source code is no longer open source the reason is this is cause the code uses private stuff like database, etc.

The currently open source github code is very outdated so m gonna remove it so people dont get confused with the updates on the github client and the actual site (since the server and site now use the secure private repo data)
