### PR TITLE
Enable link checks for gamedev.social

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
           --exclude '[^\w]todo[^\w]?'
           --exclude 'https://(www\.|old\.)?reddit\.com'
           --exclude 'https://www.patreon.com'
-          --exclude 'https://gamedev.social'
           ${{ steps.changed-files.outputs.changed_files }}
     - name: Install Zola
       run: |


### PR DESCRIPTION
The site had some trouble earlier, so I temporarily disabled link checks.