### PR TITLE
Add doc pointers to the embed_video shortcode

### DIFF
--- a/.github/newsletter-issue-template.md
+++ b/.github/newsletter-issue-template.md
@@ -102,7 +102,9 @@ but here are the most important rules:
 - Only one image per section is allowed.
   - The maximum size is 300kb for static images and 2.5mb for GIFs.
   - The image should come before the text, and must have alt text for accessibility.
-  - Prefer static images to GIFs, to keep the page load times down.
+  - Prefer static images to GIFs/videos, to keep the page load times down.
+  - To include a video, encode it as `H.264` in an `mp4` container and use
+    the `embed_video()` shortcode; videos autoplay in a loop (muted).
 - Each section should be under 1000 characters, and under 6 paragraphs.
   - This only applies to the rendered text, not the markup.
 - Keep formatting minimal - no bold/italics/etc.
@@ -117,6 +119,10 @@ Please use these templates as a starting point:
 
 ![alt text](img)
 _optional image label_
+
+OR
+
+{{ embed_video(type="video/mp4", src="my-video.mp4", caption="optional video caption") }}
 
 [Game name] ([GitHub], [Discord], [Twitter]) by [@nickname]
 is... {short project description in one sentence}.
@@ -135,6 +141,10 @@ _Discussions: [/r/rust_gamedev](link), [Twitter](link), [etc](link)_
 
 ![alt text](img)
 _optional image label_
+
+OR
+
+{{ embed_video(type="video/mp4", src="my-video.mp4", caption="optional video caption") }}
 
 [@nickname] published an [article] about...
 {overview what the resource is about}.

--- a/.github/newsletter-template.md
+++ b/.github/newsletter-template.md
@@ -53,6 +53,10 @@ Ideal section structure is:
 ![image/GIF description](image link)
 _image caption_
 
+OR
+
+{{ embed_video(type="video/mp4", src="my-video.mp4", caption="optional video caption") }}
+
 A paragraph or two with a summary and [useful links].
 
 _Discussions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,13 @@
 
 Thank you for contributing to the newsletter! 💖
 
-- [Writing Newsletter Sections](#writing-newsletter-sections)
-  - [Templates](#templates)
-  - [Style Guidelines](#style-guidelines)
-- [Becoming an Editor](#becoming-an-editor)
+- [Contributing Guide](#contributing-guide)
+  - [Writing Newsletter Sections](#writing-newsletter-sections)
+    - [Templates](#templates)
+      - [Games, Apps or Libraries](#games-apps-or-libraries)
+      - [Articles, Blog Posts or Videos](#articles-blog-posts-or-videos)
+    - [Style Guidelines](#style-guidelines)
+  - [Becoming an Editor](#becoming-an-editor)
 
 ## Writing Newsletter Sections
 
@@ -74,6 +77,10 @@ _Discussions: [/r/rust_gamedev](link), [Twitter](link), [etc](link)_
 ![alt text](img)
 _optional image label_
 
+OR
+
+{{ embed_video(type="video/mp4", src="my-video.mp4", caption="optional video caption") }}
+
 [@nickname] published an [article] about...
 {overview what the resource is about}.
 
@@ -96,11 +103,13 @@ _Discussions: [/r/rust_gamedev](link), [Twitter](link), [etc](link)_
 - Avoid having multiple/nested bullet points.
   - This guideline may be relaxed if your project has multiple parts that
     aren't independent enough for their own sections.
-- Only include one image (<300kb) or GIF (<2.5mb).
+- Only include one image (<300kb), GIF (<2.5mb) or video (<2.5mb).
   - Images should be placed before text, with an optional caption and
     mandatory alternate text for accessibility.
   - Unless essential to demonstrating your project, prefer static images
-    over GIFs, to keep the file size down.
+    over GIFs/videos, to keep the file size down.
+  - To include a video, encode it as `H.264` in an `mp4` container and use
+    the `embed_video()` shortcode; videos autoplay in a loop (muted).
 - Use singular 'they' if you’re not sure what someone's pronouns are.
 - If a project has been featured in previous newsletters, try to focus on
   what's new rather than repeating previous content.


### PR DESCRIPTION
I'm not particularly attached to H.264 but it's a codec that works well on many popular platforms.

Should close #1518 .