### PR TITLE
Fix incorrect order of comments resulting in accidental output

### DIFF
--- a/templates/shortcodes/embed_video.html
+++ b/templates/shortcodes/embed_video.html
@@ -1,9 +1,9 @@
-<!-- {#
+{# <!--
 Embed a video into a markdown file. Example usage:
 
     {{ embed_video(type="video/mp4", src="my-video.mp4", caption="Some caption.") }}
 
-#} -->
+--> #}
 <figure>
     <video controls autoplay muted loop>
         <source type="{{ type }}" src="{{ get_url(path=page.colocated_path ~ src)}}" />

--- a/templates/shortcodes/image_figure.html
+++ b/templates/shortcodes/image_figure.html
@@ -1,4 +1,4 @@
-<!-- {#
+{# <!--
     Displays an image with a legend.
 
     Example usage:
@@ -25,7 +25,7 @@
                 alt="image/GIF description"
                 src="image link"
                 caption="[image caption](https://example.com)") }}
-#} -->
+--> #}
 
 {% if src != "image link" %}
     {# Only validate against placeholders if we're not in the example #}


### PR DESCRIPTION
Follow-up to #1545:

<img width="851" alt="Screenshot 2024-07-07 at 16 34 57" src="https://github.com/rust-gamedev/rust-gamedev.github.io/assets/4602612/ac8c6f69-6140-4d9b-b84d-abc4c832c1ee">
